### PR TITLE
Fix wrong line numbers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
     #  dockerfile: debian/Dockerfile
     #  args:
     #    - "VERSION=master"
+    #    - "CODIMD_REPOSITORY=https://github.com/hackmdio/codimd.git"
     image: hackmdio/hackmd:1.2.1
-        - "CODIMD_REPOSITORY=https://github.com/hackmdio/codimd.git"
     #mem_limit: 256mb         # version 2 only
     #memswap_limit: 512mb     # version 2 only
     #read_only: true          # not supported in swarm mode, enable along with tmpfs


### PR DESCRIPTION
Due to a git perfection the line number was changed and now the build
instruction got exposed to the image version.

This patch fixes it and comments the build instructions out again.