### PR TITLE
Add implementation to mime fullversion support

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -50,13 +50,20 @@ RUN set -ex; \
 COPY resources/config.json resources/.sequelizerc /files/
 
 # Install all dependencies and build project
-RUN apk add --no-cache --virtual .dep build-base python git bash && \
+RUN apk add --no-cache --virtual .dep build-base python git jq bash && \
     # Clone the source
-    git clone --depth 1 --branch $VERSION $CODIMD_REPOSITORY /codimd && \
+    git clone --depth 1 --branch "$VERSION" "$CODIMD_REPOSITORY" /codimd && \
     # Print the cloned version and clean up git files
     cd /codimd && \
     git log --pretty=format:'%ad %h %d' --abbrev-commit --date=short -1 && echo && \
+    git rev-parse HEAD > /tmp/gitref && \
     rm -rf /codimd/.git && \
+    # Mime the git repository for fullversion
+    mkdir /codimd/.git && \
+    mv /tmp/gitref /codimd/.git/HEAD && \
+    jq ".repository.url = \"${CODIMD_REPOSITORY}\"" /codimd/package.json > /codimd/package.new.json && \
+    mv /codimd/package.new.json /codimd/package.json && \
+
     # Symlink configuration files
     rm -f /codimd/config.json && ln -s /files/config.json /codimd/config.json && \
     rm -f /codimd/.sequelizerc && ln -s /files/.sequelizerc /codimd/.sequelizerc && \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -34,14 +34,21 @@ RUN set -ex; \
 COPY resources/config.json resources/.sequelizerc /files/
 
 RUN apt-get update && \
-    apt-get install -y git build-essential && \
+    apt-get install -y git build-essential jq && \
 
     # Clone the source
-    git clone --depth 1 --branch $VERSION $CODIMD_REPOSITORY /codimd && \
+    git clone --depth 1 --branch "$VERSION" "$CODIMD_REPOSITORY" /codimd && \
     # Print the cloned version and clean up git files
     cd /codimd && \
     git log --pretty=format:'%ad %h %d' --abbrev-commit --date=short -1 && echo && \
+    git rev-parse HEAD > /tmp/gitref && \
     rm -rf /codimd/.git && \
+
+    # Mime the git repository for fullversion
+    mkdir /codimd/.git && \
+    mv /tmp/gitref /codimd/.git/HEAD && \
+    jq ".repository.url = \"${CODIMD_REPOSITORY}\"" /codimd/package.json > /codimd/package.new.json && \
+    mv /codimd/package.new.json /codimd/package.json && \
 
     # Symlink configuration files
     rm -f /codimd/config.json && ln -s /files/config.json /codimd/config.json && \
@@ -55,7 +62,7 @@ RUN apt-get update && \
     # Clean up this layer
     yarn install && \
     yarn cache clean && \
-    apt-get remove -y --auto-remove build-essential && \
+    apt-get remove -y --auto-remove build-essential git jq && \
     apt-get clean && apt-get purge && rm -r /var/lib/apt/lists/* && \
     # Create codimd user
     adduser --uid 10000 --home /codimd/ --disabled-password --system codimd && \


### PR DESCRIPTION
We just introduced fullversion support in CodiMD. This allows us
to inform all clients about every update of a container.

This patch adds some container specific tricks to keep the current
commit and repository available for this fullversion script, so whenever
someone uses those Dockerfiles to build a container, the source URL for
the CodiMD from this container is correct.

https://github.com/hackmdio/codimd/pull/991
https://github.com/hackmdio/codimd/commit/bcc914a7735290b86e0df428aed75dabdf9f1eca