### PR TITLE
Fix volumes after rename

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,9 +59,9 @@ services:
     #read_only: true          # not supported in swarm mode, enable along with tmpfs
     #tmpfs:
     #  - /tmp:size=512K
-    #  - /hackmd/tmp:size=1M
+    #  - /codimd/tmp:size=1M
     #  # Make sure you remove this when you use filesystem as upload type
-    #  - /hackmd/public/uploads:size=10M
+    #  - /codimd/public/uploads:size=10M
     environment:
       # DB_URL is formatted like: <databasetype>://<username>:<password>@<hostname>/<database>
       # Other examples are:


### PR DESCRIPTION
We renamed all internal paths to `/codimd`. There were some changes 
missing in the `docker-compose.yml`.

This patch adds those changes so whenever someone tries to use the 
compose file, they'll use the right paths.

Fixes #15 