### PR TITLE
Add fonts for PDF exports

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -35,6 +35,8 @@ COPY resources/config.json resources/.sequelizerc /files/
 
 RUN apt-get update && \
     apt-get install -y git build-essential jq && \
+    # Add fonts for PDF export
+    apt-get install -y fonts-noto && \
 
     # Clone the source
     git clone --depth 1 --branch "$VERSION" "$CODIMD_REPOSITORY" /codimd && \


### PR DESCRIPTION
We noticed that Chinese characters don't work on PDF exports and result
in unknown characters.

This patch installs the noto font set that includes CJK fonts. This
should fix PDF exports.